### PR TITLE
Add token-based authentication and secure UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,62 +2,261 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>SCI LemMarket - SQLite Edition</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SCI LemMarket - Gestion sécurisée</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    body { font-family: 'Inter', sans-serif; }
+  </style>
 </head>
-<body class="p-8 bg-gray-100">
-  <h1 class="text-3xl font-bold mb-4">SCI LemMarket</h1>
+<body class="bg-gray-100 min-h-screen">
+  <!-- Login Section -->
+  <div id="login-section" class="min-h-screen flex items-center justify-center p-4">
+    <div class="w-full max-w-md p-8 bg-white rounded-lg shadow-md">
+      <div class="flex flex-col items-center mb-6">
+        <img src="https://placehold.co/160x80/10B981/ffffff?text=SCI_LemMarket" alt="Logo SCI LemMarket" class="mb-4" />
+        <h2 class="text-2xl font-bold text-gray-800">Connexion</h2>
+      </div>
+      <form id="login-form" class="space-y-4">
+        <div>
+          <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+          <input type="email" id="email" name="email" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 p-2" />
+        </div>
+        <div>
+          <label for="password" class="block text-sm font-medium text-gray-700">Mot de passe</label>
+          <input type="password" id="password" name="password" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 p-2" />
+        </div>
+        <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2 rounded-md transition duration-300">
+          Se connecter
+        </button>
+      </form>
+      <p id="auth-status" class="mt-4 text-center text-sm text-red-500 hidden"></p>
+    </div>
+  </div>
 
-  <section>
-    <h2 class="text-xl font-bold">Mandats</h2>
-    <form id="mandatForm" class="mb-4 space-x-2">
-      <input type="text" name="numero" placeholder="Numéro" class="border p-2" required />
-      <input type="text" name="typeMandat" placeholder="Type" class="border p-2" />
-      <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">Ajouter</button>
-    </form>
-    <table class="min-w-full bg-white" id="mandatTable"><tbody></tbody></table>
-  </section>
+  <!-- Admin Section -->
+  <div id="admin-section" class="hidden max-w-4xl mx-auto p-6 md:p-10">
+    <div class="bg-white shadow-md rounded-lg p-6">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+        <div>
+          <h2 class="text-2xl font-bold text-gray-800">Gestion des utilisateurs</h2>
+          <p class="text-gray-500 text-sm">Créer de nouveaux comptes et attribuer des rôles.</p>
+        </div>
+        <div class="flex gap-2">
+          <button id="back-to-app" class="bg-gray-700 hover:bg-gray-800 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+            Retour aux registres
+          </button>
+        </div>
+      </div>
+      <form id="create-user-form" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label for="new-user-email" class="block text-sm font-medium text-gray-700">Email</label>
+          <input type="email" id="new-user-email" name="email" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 p-2" />
+        </div>
+        <div>
+          <label for="new-user-password" class="block text-sm font-medium text-gray-700">Mot de passe</label>
+          <input type="password" id="new-user-password" name="password" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 p-2" />
+        </div>
+        <div>
+          <label for="new-user-role" class="block text-sm font-medium text-gray-700">Rôle</label>
+          <select id="new-user-role" name="role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 p-2">
+            <option value="agent">Agent</option>
+            <option value="admin">Administrateur</option>
+          </select>
+        </div>
+        <div class="md:col-span-2 flex items-end">
+          <button type="submit" class="w-full md:w-auto bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-2 rounded-md transition duration-300">
+            Créer l'utilisateur
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
 
-  <section class="mt-8">
-    <h2 class="text-xl font-bold">Transactions</h2>
-    <form id="transactionForm" class="mb-4 space-x-2">
-      <input type="text" name="numero" placeholder="Numéro" class="border p-2" required />
-      <input type="text" name="bien" placeholder="Bien" class="border p-2" />
-      <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">Ajouter</button>
-    </form>
-    <table class="min-w-full bg-white" id="transactionTable"><tbody></tbody></table>
-  </section>
+  <!-- Main Application Section -->
+  <div id="main-app-section" class="hidden max-w-7xl mx-auto p-4 md:p-8">
+    <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+      <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-800">Registres SCI LemMarket</h1>
+          <p class="text-gray-500">Gérez vos mandats, transactions et suivis en toute sécurité.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3">
+          <span id="user-info" class="text-gray-600 text-sm"></span>
+          <button id="admin-button" class="hidden bg-gray-800 hover:bg-gray-900 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+            Gestion des utilisateurs
+          </button>
+          <button id="logout-button" class="bg-red-600 hover:bg-red-700 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+            Déconnexion
+          </button>
+        </div>
+      </div>
+    </div>
 
-  <section class="mt-8">
-    <h2 class="text-xl font-bold">Suivi</h2>
-    <form id="suiviForm" class="mb-4 space-x-2">
-      <input type="text" name="numeroMandat" placeholder="Mandat" class="border p-2" required />
-      <input type="text" name="action" placeholder="Action" class="border p-2" />
-      <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">Ajouter</button>
-    </form>
-    <table class="min-w-full bg-white" id="suiviTable"><tbody></tbody></table>
-  </section>
+    <div class="bg-white rounded-lg shadow-md p-4 md:p-6 mb-6">
+      <div class="flex flex-wrap gap-2 md:gap-4">
+        <button class="nav-button bg-gray-800 text-white font-semibold px-4 py-2 rounded-md transition duration-300" data-section="mandats">Mandats</button>
+        <button class="nav-button bg-gray-200 text-gray-700 font-semibold px-4 py-2 rounded-md transition duration-300" data-section="transactions">Transactions</button>
+        <button class="nav-button bg-gray-200 text-gray-700 font-semibold px-4 py-2 rounded-md transition duration-300" data-section="suivi">Suivi</button>
+        <button class="nav-button bg-gray-200 text-gray-700 font-semibold px-4 py-2 rounded-md transition duration-300" data-section="recherche">Recherche</button>
+        <button class="nav-button bg-gray-200 text-gray-700 font-semibold px-4 py-2 rounded-md transition duration-300" data-section="gestion">Gestion locative</button>
+      </div>
+    </div>
 
-  <section class="mt-8">
-    <h2 class="text-xl font-bold">Recherche</h2>
-    <form id="rechercheForm" class="mb-4 space-x-2">
-      <input type="text" name="numero" placeholder="Numéro" class="border p-2" required />
-      <input type="text" name="client" placeholder="Client" class="border p-2" />
-      <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">Ajouter</button>
-    </form>
-    <table class="min-w-full bg-white" id="rechercheTable"><tbody></tbody></table>
-  </section>
+    <div id="status-message" class="hidden mb-4">
+      <div class="bg-red-100 border border-red-300 text-red-700 px-4 py-3 rounded">
+        <p id="status-text"></p>
+      </div>
+    </div>
 
-  <section class="mt-8">
-    <h2 class="text-xl font-bold">Gestion locative</h2>
-    <form id="gestionForm" class="mb-4 space-x-2">
-      <input type="text" name="numeroBien" placeholder="Numéro Bien" class="border p-2" required />
-      <input type="text" name="locataire" placeholder="Locataire" class="border p-2" />
-      <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">Ajouter</button>
-    </form>
-    <table class="min-w-full bg-white" id="gestionTable"><tbody></tbody></table>
-  </section>
+    <div id="register-container" class="space-y-6">
+      <section class="register-section" data-section="mandats">
+        <div class="bg-white shadow-md rounded-lg p-6 space-y-6">
+          <div>
+            <h2 class="text-2xl font-semibold text-gray-800 mb-4">Registre des mandats</h2>
+            <form id="mandatForm" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <input type="text" name="numero" placeholder="Numéro" class="border rounded-md p-2" required />
+              <input type="text" name="typeMandat" placeholder="Type" class="border rounded-md p-2" />
+              <div class="md:col-span-2">
+                <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+                  Ajouter un mandat
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200" id="mandatTable">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Numéro</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section class="register-section hidden" data-section="transactions">
+        <div class="bg-white shadow-md rounded-lg p-6 space-y-6">
+          <div>
+            <h2 class="text-2xl font-semibold text-gray-800 mb-4">Registre des transactions</h2>
+            <form id="transactionForm" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <input type="text" name="numero" placeholder="Numéro" class="border rounded-md p-2" required />
+              <input type="text" name="bien" placeholder="Bien" class="border rounded-md p-2" />
+              <div class="md:col-span-2">
+                <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+                  Ajouter une transaction
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200" id="transactionTable">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Numéro</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Bien</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section class="register-section hidden" data-section="suivi">
+        <div class="bg-white shadow-md rounded-lg p-6 space-y-6">
+          <div>
+            <h2 class="text-2xl font-semibold text-gray-800 mb-4">Registre de suivi</h2>
+            <form id="suiviForm" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <input type="text" name="numeroMandat" placeholder="Mandat" class="border rounded-md p-2" required />
+              <input type="text" name="action" placeholder="Action" class="border rounded-md p-2" />
+              <div class="md:col-span-2">
+                <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+                  Ajouter un suivi
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200" id="suiviTable">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Mandat</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section class="register-section hidden" data-section="recherche">
+        <div class="bg-white shadow-md rounded-lg p-6 space-y-6">
+          <div>
+            <h2 class="text-2xl font-semibold text-gray-800 mb-4">Registre de recherche</h2>
+            <form id="rechercheForm" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <input type="text" name="numero" placeholder="Numéro" class="border rounded-md p-2" required />
+              <input type="text" name="client" placeholder="Client" class="border rounded-md p-2" />
+              <div class="md:col-span-2">
+                <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+                  Ajouter une recherche
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200" id="rechercheTable">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Numéro</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Client</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section class="register-section hidden" data-section="gestion">
+        <div class="bg-white shadow-md rounded-lg p-6 space-y-6">
+          <div>
+            <h2 class="text-2xl font-semibold text-gray-800 mb-4">Gestion locative</h2>
+            <form id="gestionForm" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <input type="text" name="numeroBien" placeholder="Numéro de bien" class="border rounded-md p-2" required />
+              <input type="text" name="locataire" placeholder="Locataire" class="border rounded-md p-2" />
+              <div class="md:col-span-2">
+                <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-4 py-2 rounded-md transition duration-300">
+                  Ajouter une fiche
+                </button>
+              </div>
+            </form>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200" id="gestionTable">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Numéro de bien</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Locataire</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
 
   <script type="module" src="./src/ui.js"></script>
 </body>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,21 +1,107 @@
 const API_URL = "http://localhost:5000/api";
 
+let authToken = localStorage.getItem("authToken");
+
+function setAuthToken(token) {
+  authToken = token;
+  if (token) {
+    localStorage.setItem("authToken", token);
+  } else {
+    localStorage.removeItem("authToken");
+  }
+}
+
+function getHeaders(includeJson = true) {
+  const headers = {};
+  if (includeJson) {
+    headers["Content-Type"] = "application/json";
+  }
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+  return headers;
+}
+
+async function request(method, endpoint, data = null, { skipAuth = false } = {}) {
+  const url = `${API_URL}/${endpoint}`;
+  const options = { method, headers: {} };
+
+  if (method !== "GET" && method !== "HEAD") {
+    options.headers = getHeaders(true);
+  } else {
+    options.headers = getHeaders(false);
+  }
+
+  if (skipAuth && options.headers.Authorization) {
+    delete options.headers.Authorization;
+  }
+
+  if (data !== null && method !== "GET" && method !== "HEAD") {
+    options.body = JSON.stringify(data);
+  }
+
+  const response = await fetch(url, options);
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const error = new Error(payload?.error || payload?.message || "Une erreur est survenue");
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+}
+
 async function fetchData(endpoint) {
-  const res = await fetch(`${API_URL}/${endpoint}`);
-  return res.json();
+  return request("GET", endpoint);
 }
 
 async function postData(endpoint, data) {
-  const res = await fetch(`${API_URL}/${endpoint}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data)
-  });
-  return res.json();
+  return request("POST", endpoint, data);
 }
 
 async function deleteData(endpoint, id) {
-  await fetch(`${API_URL}/${endpoint}/${id}`, { method: "DELETE" });
+  return request("DELETE", `${endpoint}/${id}`);
 }
 
-export const api = { fetchData, postData, deleteData };
+async function login(email, password) {
+  const result = await request("POST", "auth/login", { email, password }, { skipAuth: true });
+  setAuthToken(result.token);
+  return result;
+}
+
+async function logout() {
+  try {
+    await request("POST", "auth/logout", {});
+  } catch (error) {
+    if (error.status !== 401) {
+      throw error;
+    }
+  } finally {
+    setAuthToken(null);
+  }
+}
+
+async function me() {
+  return request("GET", "auth/me");
+}
+
+async function createUser(data) {
+  return request("POST", "users", data);
+}
+
+export const api = {
+  fetchData,
+  postData,
+  deleteData,
+  login,
+  logout,
+  me,
+  createUser,
+  setAuthToken,
+  get token() {
+    return authToken;
+  }
+};

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -1,39 +1,316 @@
 import { api } from "./api.js";
 
-function setupForm(tableId, formId, endpoint, fields) {
-  const form = document.getElementById(formId);
-  const tableBody = document.querySelector(`#${tableId} tbody`);
+const registerConfigs = [
+  { name: "mandats", tableId: "mandatTable", formId: "mandatForm", endpoint: "mandats", fields: ["numero", "typeMandat"] },
+  { name: "transactions", tableId: "transactionTable", formId: "transactionForm", endpoint: "transactions", fields: ["numero", "bien"] },
+  { name: "suivi", tableId: "suiviTable", formId: "suiviForm", endpoint: "suivi", fields: ["numeroMandat", "action"] },
+  { name: "recherche", tableId: "rechercheTable", formId: "rechercheForm", endpoint: "recherche", fields: ["numero", "client"] },
+  { name: "gestion", tableId: "gestionTable", formId: "gestionForm", endpoint: "gestion", fields: ["numeroBien", "locataire"] }
+];
 
-  async function refresh() {
-    const items = await api.fetchData(endpoint);
-    tableBody.innerHTML = "";
-    items.forEach(i => {
-      const tr = document.createElement("tr");
-      tr.innerHTML = fields.map(f => `<td class='border px-2'>${i[f]||""}</td>`).join("")
-        + `<td><button data-id="${i.id}" class="delete-btn bg-red-500 text-white px-2">X</button></td>`;
-      tableBody.appendChild(tr);
-    });
-    tableBody.querySelectorAll(".delete-btn").forEach(btn => {
-      btn.addEventListener("click", async () => {
-        await api.deleteData(endpoint, btn.dataset.id);
-        refresh();
-      });
-    });
+const registerControllers = new Map();
+let registersInitialized = false;
+let currentUser = null;
+
+const loginSection = document.getElementById("login-section");
+const loginForm = document.getElementById("login-form");
+const authStatus = document.getElementById("auth-status");
+const mainSection = document.getElementById("main-app-section");
+const adminSection = document.getElementById("admin-section");
+const logoutButton = document.getElementById("logout-button");
+const adminButton = document.getElementById("admin-button");
+const backToAppButton = document.getElementById("back-to-app");
+const createUserForm = document.getElementById("create-user-form");
+const userInfo = document.getElementById("user-info");
+const navButtons = document.querySelectorAll(".nav-button");
+const registerSections = document.querySelectorAll(".register-section");
+const statusMessage = document.getElementById("status-message");
+const statusText = document.getElementById("status-text");
+const statusBox = statusMessage?.querySelector("div");
+
+const STATUS_CLASSES = {
+  error: "bg-red-100 border border-red-300 text-red-700",
+  success: "bg-green-100 border border-green-300 text-green-700"
+};
+
+function showStatus(message, type = "error") {
+  if (!statusMessage || !statusText || !statusBox) {
+    return;
   }
-
-  form.addEventListener("submit", async (e) => {
-    e.preventDefault();
-    const data = Object.fromEntries(new FormData(form));
-    await api.postData(endpoint, data);
-    form.reset();
-    refresh();
-  });
-
-  refresh();
+  statusText.textContent = message;
+  statusMessage.classList.remove("hidden");
+  statusBox.className = `${STATUS_CLASSES[type] || STATUS_CLASSES.error} px-4 py-3 rounded`;
 }
 
-setupForm("mandatTable", "mandatForm", "mandats", ["numero","typeMandat"]);
-setupForm("transactionTable", "transactionForm", "transactions", ["numero","bien"]);
-setupForm("suiviTable", "suiviForm", "suivi", ["numeroMandat","action"]);
-setupForm("rechercheTable", "rechercheForm", "recherche", ["numero","client"]);
-setupForm("gestionTable", "gestionForm", "gestion", ["numeroBien","locataire"]);
+function hideStatus() {
+  if (!statusMessage || !statusText || !statusBox) {
+    return;
+  }
+  statusMessage.classList.add("hidden");
+  statusText.textContent = "";
+}
+
+function clearTables() {
+  registerConfigs.forEach((config) => {
+    const tableBody = document.querySelector(`#${config.tableId} tbody`);
+    if (tableBody) {
+      tableBody.innerHTML = "";
+    }
+  });
+}
+
+function finalizeLogout(message = "") {
+  currentUser = null;
+  hideStatus();
+  clearTables();
+  if (userInfo) {
+    userInfo.textContent = "";
+  }
+  if (adminButton) {
+    adminButton.classList.add("hidden");
+  }
+  if (adminSection) {
+    adminSection.classList.add("hidden");
+  }
+  if (mainSection) {
+    mainSection.classList.add("hidden");
+  }
+  if (loginSection) {
+    loginSection.classList.remove("hidden");
+  }
+  if (message && authStatus) {
+    authStatus.textContent = message;
+    authStatus.classList.remove("hidden");
+  } else if (authStatus) {
+    authStatus.textContent = "";
+    authStatus.classList.add("hidden");
+  }
+}
+
+function handleAuthError(error) {
+  if (error?.status === 401) {
+    finalizeLogout("Votre session a expiré. Veuillez vous reconnecter.");
+    api.setAuthToken(null);
+    return;
+  }
+  showStatus(error?.message || "Une erreur est survenue", "error");
+}
+
+function activateSection(sectionName) {
+  navButtons.forEach((button) => {
+    if (button.dataset.section === sectionName) {
+      button.classList.remove("bg-gray-200", "text-gray-700");
+      button.classList.add("bg-gray-800", "text-white");
+    } else {
+      button.classList.add("bg-gray-200", "text-gray-700");
+      button.classList.remove("bg-gray-800", "text-white");
+    }
+  });
+
+  registerSections.forEach((section) => {
+    section.classList.toggle("hidden", section.dataset.section !== sectionName);
+  });
+
+  const controller = registerControllers.get(sectionName);
+  if (controller) {
+    controller.refresh();
+  }
+}
+
+function setupForm(config) {
+  const form = document.getElementById(config.formId);
+  const tableBody = document.querySelector(`#${config.tableId} tbody`);
+
+  async function refresh() {
+    if (!tableBody || !currentUser) {
+      return;
+    }
+    try {
+      const items = await api.fetchData(config.endpoint);
+      tableBody.innerHTML = "";
+      items.forEach((item) => {
+        const row = document.createElement("tr");
+        row.className = "border-b last:border-b-0";
+        const cells = config.fields
+          .map((field) => `<td class="px-4 py-2 text-sm text-gray-700">${item[field] || ""}</td>`)
+          .join("");
+        row.innerHTML = `${cells}<td class="px-4 py-2 text-sm text-right"><button data-id="${item.id}" class="delete-btn text-red-600 hover:text-red-800 font-semibold">Supprimer</button></td>`;
+        tableBody.appendChild(row);
+      });
+
+      tableBody.querySelectorAll(".delete-btn").forEach((button) => {
+        button.addEventListener("click", async () => {
+          try {
+            await api.deleteData(config.endpoint, button.dataset.id);
+            refresh();
+            showStatus("Entrée supprimée avec succès.", "success");
+          } catch (error) {
+            handleAuthError(error);
+          }
+        });
+      });
+    } catch (error) {
+      handleAuthError(error);
+    }
+  }
+
+  if (form && !form.dataset.initialized) {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      hideStatus();
+      const formData = Object.fromEntries(new FormData(form));
+      try {
+        await api.postData(config.endpoint, formData);
+        form.reset();
+        showStatus("Entrée enregistrée avec succès.", "success");
+        refresh();
+      } catch (error) {
+        handleAuthError(error);
+      }
+    });
+    form.dataset.initialized = "true";
+  }
+
+  return { refresh };
+}
+
+function initializeRegisters() {
+  if (registersInitialized) {
+    return;
+  }
+  registerConfigs.forEach((config) => {
+    registerControllers.set(config.name, setupForm(config));
+  });
+  registersInitialized = true;
+}
+
+function refreshAllRegisters() {
+  registerControllers.forEach((controller) => {
+    controller.refresh();
+  });
+}
+
+function handleAuthSuccess(user) {
+  currentUser = user;
+  if (loginSection) {
+    loginSection.classList.add("hidden");
+  }
+  if (adminSection) {
+    adminSection.classList.add("hidden");
+  }
+  if (mainSection) {
+    mainSection.classList.remove("hidden");
+  }
+  if (authStatus) {
+    authStatus.textContent = "";
+    authStatus.classList.add("hidden");
+  }
+  if (userInfo) {
+    userInfo.textContent = `Connecté en tant que ${user.email} (${user.role})`;
+  }
+  if (adminButton) {
+    adminButton.classList.toggle("hidden", user.role !== "admin");
+  }
+  hideStatus();
+  initializeRegisters();
+  refreshAllRegisters();
+  activateSection("mandats");
+}
+
+async function attemptRehydrate() {
+  if (!api.token) {
+    finalizeLogout();
+    return;
+  }
+  try {
+    const { user } = await api.me();
+    handleAuthSuccess(user);
+  } catch (error) {
+    api.setAuthToken(null);
+    finalizeLogout();
+  }
+}
+
+if (loginForm) {
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    hideStatus();
+    if (authStatus) {
+      authStatus.classList.add("hidden");
+    }
+    const formData = new FormData(loginForm);
+    const email = formData.get("email");
+    const password = formData.get("password");
+    try {
+      const { user } = await api.login(email, password);
+      loginForm.reset();
+      handleAuthSuccess(user);
+    } catch (error) {
+      if (authStatus) {
+        authStatus.textContent = error?.message || "Impossible de se connecter";
+        authStatus.classList.remove("hidden");
+      }
+    }
+  });
+}
+
+if (logoutButton) {
+  logoutButton.addEventListener("click", async () => {
+    try {
+      await api.logout();
+    } catch (error) {
+      if (error.status && error.status !== 401) {
+        showStatus(error.message, "error");
+        return;
+      }
+    }
+    finalizeLogout();
+  });
+}
+
+if (adminButton) {
+  adminButton.addEventListener("click", () => {
+    hideStatus();
+    if (mainSection) {
+      mainSection.classList.add("hidden");
+    }
+    if (adminSection) {
+      adminSection.classList.remove("hidden");
+    }
+  });
+}
+
+if (backToAppButton) {
+  backToAppButton.addEventListener("click", () => {
+    hideStatus();
+    if (adminSection) {
+      adminSection.classList.add("hidden");
+    }
+    if (mainSection) {
+      mainSection.classList.remove("hidden");
+    }
+  });
+}
+
+if (createUserForm) {
+  createUserForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    hideStatus();
+    const formData = Object.fromEntries(new FormData(createUserForm));
+    try {
+      await api.createUser(formData);
+      createUserForm.reset();
+      showStatus("Nouvel utilisateur créé avec succès.", "success");
+    } catch (error) {
+      handleAuthError(error);
+    }
+  });
+}
+
+navButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    activateSection(button.dataset.section);
+  });
+});
+
+attemptRehydrate();


### PR DESCRIPTION
## Summary
- add user and token models with helper utilities to enforce bearer authentication and admin-controlled user creation
- expose login, logout, session introspection, and secured CRUD API routes while seeding a default administrator
- redesign the frontend with a login view, admin panel, authenticated register navigation, and token-aware API client

## Testing
- python -m compileall registre/backend

------
https://chatgpt.com/codex/tasks/task_e_68da953d2194832cb284d20316e8b428