### PR TITLE
Add Docker and Apache configuration for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ python app.py
 ```bash
 cd frontend
 npm install
+echo "VITE_API_URL=http://localhost:5000/api" > .env.local
 npm run dev
 ```
 Accéder à http://localhost:3000
+
+> L'application frontend interroge l'API via l'URL définie dans la variable `VITE_API_URL`. En production la valeur par défaut `/api` est utilisée, ce qui permet de passer par le proxy Apache défini dans `registre.conf`.
 
 ---
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY backend/requirements.txt backend/requirements.txt
+RUN pip install --no-cache-dir -r backend/requirements.txt
+
+COPY backend/ backend/
+
+EXPOSE 5000
+
+CMD ["python", "backend/app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "127.0.0.1:5000:5000"
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - backend
+    restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:alpine
+
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/dist/ /usr/share/nginx/html/
+
+EXPOSE 3000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 3000;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,5 @@
-const API_URL = "http://localhost:5000/api";
+const rawApiUrl = import.meta?.env?.VITE_API_URL;
+const API_URL = (rawApiUrl ? rawApiUrl : "/api").replace(/\/+$/, "");
 
 let authToken = localStorage.getItem("authToken");
 
@@ -23,7 +24,8 @@ function getHeaders(includeJson = true) {
 }
 
 async function request(method, endpoint, data = null, { skipAuth = false } = {}) {
-  const url = `${API_URL}/${endpoint}`;
+  const normalizedEndpoint = endpoint.replace(/^\/+/, "");
+  const url = `${API_URL}/${normalizedEndpoint}`;
   const options = { method, headers: {} };
 
   if (method !== "GET" && method !== "HEAD") {

--- a/registre.conf
+++ b/registre.conf
@@ -1,0 +1,14 @@
+<VirtualHost *:80>
+    ServerName registre.lem-immobilier.com
+
+    ProxyPreserveHost On
+
+    ProxyPass /api http://127.0.0.1:5000/api
+    ProxyPassReverse /api http://127.0.0.1:5000/api
+
+    ProxyPass / http://127.0.0.1:3000/
+    ProxyPassReverse / http://127.0.0.1:3000/
+
+    ErrorLog ${APACHE_LOG_DIR}/registre-error.log
+    CustomLog ${APACHE_LOG_DIR}/registre-access.log combined
+</VirtualHost>


### PR DESCRIPTION
## Summary
- add a backend Dockerfile that installs dependencies and runs the Flask app entrypoint
- add an nginx-based frontend Dockerfile and configuration to serve the built assets on port 3000
- add docker-compose and Apache virtual host configuration for reverse proxying to the containers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf3d4ec78832cb2c7fe733e01a554