### PR TITLE
Fix frontend Docker build and proxy configuration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,7 +12,20 @@ from sqlalchemy import text
 from werkzeug.security import generate_password_hash, check_password_hash
 
 app = Flask(__name__)
-ALLOWED_ORIGINS = {"http://localhost:5173", "http://127.0.0.1:5173"}
+
+
+def _parse_origins(raw_origins: str) -> set[str]:
+    return {origin.strip() for origin in raw_origins.split(',') if origin.strip()}
+
+
+_default_origins = {
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+}
+
+ALLOWED_ORIGINS = _parse_origins(os.getenv("ALLOWED_ORIGINS", "")) or _default_origins
 
 CORS(
     app,

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,3 @@
-# <<<<<<< codex/deploy-application-with-docker-and-apache
 # Build stage: compile the frontend assets
 FROM node:20-alpine AS build
 WORKDIR /app
@@ -13,17 +12,10 @@ RUN npm run build
 
 # Runtime stage: serve the compiled assets with nginx
 FROM nginx:alpine
+
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist/ /usr/share/nginx/html/
 
 EXPOSE 3000
-# =======
-# FROM nginx:alpine
 
-# COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
-# COPY frontend/dist/ /usr/share/nginx/html/
-
-# EXPOSE 3000
-
-# >>>>>>> master
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,4 +8,13 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
+
+    location /api/ {
+        proxy_pass http://backend:5000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,21 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: { port: 3000 }
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const proxyTarget = env.VITE_DEV_API_PROXY || 'http://localhost:5000';
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- clean up the frontend Dockerfile so the image builds assets with Node and serves them through nginx
- proxy API calls through nginx in production and configure the Vite dev server to forward /api to the backend
- allow configuring backend CORS origins via environment variables and include localhost:3000 by default

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ded8b87bec832c8d58b18e1d0ab42e