### PR TITLE
Harmonize mandate references and client capture across registers

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -63,68 +63,96 @@ class User(db.Model):
 
 class Mandat(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    numero = db.Column(db.String(50), nullable=False)
-    dateSignature = db.Column(db.String(50))
+    referenceMandat = db.Column('numero', db.String(50), nullable=False)
+    dateDebut = db.Column('dateSignature', db.String(50))
+    dateEcheance = db.Column(db.String(50))
     typeMandat = db.Column(db.String(50))
-    statutMandat = db.Column(db.String(50))
     typeTransaction = db.Column(db.String(50))
-    proprietaire = db.Column(db.String(100))
-    adresse = db.Column(db.Text)
-    caracteristiques = db.Column(db.Text)
-    prixSouhaite = db.Column(db.String(50))
-    commission = db.Column(db.String(50))
-    validite = db.Column(db.String(50))
-    dateFinalisation = db.Column(db.String(50))
-    acquereur = db.Column(db.String(100))
+    statutMandat = db.Column(db.String(50))
+    typeBien = db.Column(db.String(100))
+    adresseBien = db.Column('adresse', db.Text)
+    surfaceM2 = db.Column(db.String(50))
+    nbPieces = db.Column(db.String(50))
+    dpeClassement = db.Column(db.String(10))
+    prixDemande = db.Column('prixSouhaite', db.String(50))
+    honorairePourcent = db.Column('commission', db.String(50))
+    tvaApplicable = db.Column(db.String(20))
+    proprietaireNom = db.Column('proprietaire', db.String(120))
+    proprietaireCoordonnees = db.Column(db.Text)
+    clientVendeurInfos = db.Column(db.Text)
+    clientAcheteurInfos = db.Column('acquereur', db.Text)
+    agentResponsable = db.Column(db.String(120))
+    notesMandat = db.Column('caracteristiques', db.Text)
+    descriptionBien = db.Column(db.Text)
 
 
 class Transaction(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     numeroTransaction = db.Column(db.String(50), nullable=False)
-    dateTransaction = db.Column(db.String(50))
-    mandatRef = db.Column(db.String(50))
+    dateSignature = db.Column('dateTransaction', db.String(50))
+    referenceMandat = db.Column('mandatRef', db.String(50))
     typeTransaction = db.Column(db.String(50))
-    bien = db.Column(db.String(200))
-    prix = db.Column(db.String(50))
-    commissionTotale = db.Column(db.String(50))
-    client = db.Column(db.String(120))
-    observations = db.Column(db.Text)
+    clientVendeur = db.Column(db.String(120))
+    acquereurLocataire = db.Column('client', db.String(120))
+    notaire = db.Column(db.String(120))
+    prixFinal = db.Column('prix', db.String(50))
+    commissionHT = db.Column('commissionTotale', db.String(50))
+    montantTVA = db.Column(db.String(50))
+    conditionsSusp = db.Column(db.String(20))
+    statutReglement = db.Column(db.String(50))
+    notesTransaction = db.Column('observations', db.Text)
 
 
 class Suivi(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    numeroMandat = db.Column(db.String(50), nullable=False)
-    dateSuivi = db.Column(db.String(50))
-    action = db.Column(db.String(100))
-    contact = db.Column(db.String(120))
-    resultat = db.Column(db.String(200))
+    referenceMandat = db.Column('numeroMandat', db.String(50), nullable=False)
+    dateAction = db.Column('dateSuivi', db.String(50))
+    typeAction = db.Column('action', db.String(100))
+    contactClient = db.Column('contact', db.String(120))
+    intensiteAction = db.Column(db.String(20))
+    details = db.Column('resultat', db.Text)
     prochaineEtape = db.Column(db.String(200))
-    datePrevue = db.Column(db.String(50))
+    dateProchaineAction = db.Column('datePrevue', db.String(50))
+    agent = db.Column(db.String(120))
 
 
 class Recherche(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     numeroDemande = db.Column(db.String(50), nullable=False)
     dateDemande = db.Column(db.String(50))
-    client = db.Column(db.String(120))
-    typeBien = db.Column(db.String(120))
-    budget = db.Column(db.String(50))
-    criteres = db.Column(db.Text)
+    clientNom = db.Column('client', db.String(120))
+    telephone = db.Column(db.String(50))
+    typeRecherche = db.Column(db.String(120))
+    budgetMin = db.Column(db.String(50))
+    budgetMax = db.Column(db.String(50))
+    secteurGeographique = db.Column(db.Text)
+    delaiSouhaite = db.Column(db.String(50))
+    motivations = db.Column(db.Text)
+    criteresSpecifiques = db.Column('criteres', db.Text)
     biensProposes = db.Column(db.Text)
     statutDemande = db.Column(db.String(100))
+    agentSuivi = db.Column(db.String(120))
 
 
 class GestionLocative(db.Model):
     id = db.Column(db.Integer, primary_key=True)
+    referenceMandat = db.Column(db.String(50))
     numeroBien = db.Column(db.String(50), nullable=False)
-    adresse = db.Column(db.Text)
-    proprietaire = db.Column(db.String(120))
-    locataire = db.Column(db.String(120))
-    dateDebutBail = db.Column(db.String(50))
-    loyer = db.Column(db.String(50))
-    statutLoyer = db.Column(db.String(100))
+    adresseBien = db.Column('adresse', db.Text)
+    proprietaireNom = db.Column('proprietaire', db.String(120))
+    proprietaireCoordonnees = db.Column(db.Text)
+    locataireNom = db.Column('locataire', db.String(120))
+    locataireCoordonnees = db.Column(db.Text)
+    debutBail = db.Column('dateDebutBail', db.String(50))
+    finBail = db.Column(db.String(50))
+    montantLoyerBase = db.Column('loyer', db.String(50))
+    montantCharges = db.Column(db.String(50))
+    depotGarantie = db.Column(db.String(50))
+    irl = db.Column(db.String(50))
+    dateProchaineIndexation = db.Column(db.String(50))
+    etatPaiement = db.Column('statutLoyer', db.String(100))
     datePaiement = db.Column(db.String(50))
-    observations = db.Column(db.Text)
+    notesIncident = db.Column('observations', db.Text)
 
 # ---- HELPERS ----
 def ensure_default_admin():
@@ -144,46 +172,82 @@ def ensure_schema():
             ('dateSignature', 'VARCHAR(50)'),
             ('statutMandat', 'VARCHAR(50)'),
             ('typeTransaction', 'VARCHAR(50)'),
-            ('proprietaire', 'VARCHAR(100)'),
+            ('typeBien', 'VARCHAR(100)'),
             ('adresse', 'TEXT'),
-            ('caracteristiques', 'TEXT'),
+            ('surfaceM2', 'VARCHAR(50)'),
+            ('nbPieces', 'VARCHAR(50)'),
+            ('dpeClassement', 'VARCHAR(10)'),
             ('prixSouhaite', 'VARCHAR(50)'),
             ('commission', 'VARCHAR(50)'),
-            ('validite', 'VARCHAR(50)'),
+            ('tvaApplicable', 'VARCHAR(20)'),
+            ('proprietaire', 'VARCHAR(120)'),
+            ('proprietaireCoordonnees', 'TEXT'),
+            ('clientVendeurInfos', 'TEXT'),
+            ('acquereur', 'TEXT'),
+            ('caracteristiques', 'TEXT'),
+            ('descriptionBien', 'TEXT'),
             ('dateFinalisation', 'VARCHAR(50)'),
-            ('acquereur', 'VARCHAR(100)')
+            ('validite', 'VARCHAR(50)'),
+            ('dateEcheance', 'VARCHAR(50)'),
+            ('agentResponsable', 'VARCHAR(120)')
         ],
         'transaction': [
             ('numeroTransaction', 'VARCHAR(50)'),
             ('dateTransaction', 'VARCHAR(50)'),
             ('mandatRef', 'VARCHAR(50)'),
             ('typeTransaction', 'VARCHAR(50)'),
+            ('clientVendeur', 'VARCHAR(120)'),
             ('prix', 'VARCHAR(50)'),
             ('commissionTotale', 'VARCHAR(50)'),
             ('client', 'VARCHAR(120)'),
+            ('notaire', 'VARCHAR(120)'),
+            ('montantTVA', 'VARCHAR(50)'),
+            ('conditionsSusp', 'VARCHAR(20)'),
+            ('statutReglement', 'VARCHAR(50)'),
             ('observations', 'TEXT')
         ],
         'suivi': [
+            ('numeroMandat', 'VARCHAR(50)'),
             ('dateSuivi', 'VARCHAR(50)'),
+            ('action', 'VARCHAR(100)'),
             ('contact', 'VARCHAR(120)'),
-            ('resultat', 'VARCHAR(200)'),
+            ('intensiteAction', 'VARCHAR(20)'),
+            ('resultat', 'TEXT'),
             ('prochaineEtape', 'VARCHAR(200)'),
-            ('datePrevue', 'VARCHAR(50)')
+            ('datePrevue', 'VARCHAR(50)'),
+            ('agent', 'VARCHAR(120)')
         ],
         'recherche': [
             ('numeroDemande', 'VARCHAR(50)'),
             ('dateDemande', 'VARCHAR(50)'),
-            ('typeBien', 'VARCHAR(120)'),
+            ('client', 'VARCHAR(120)'),
+            ('telephone', 'VARCHAR(50)'),
+            ('typeRecherche', 'VARCHAR(120)'),
+            ('budgetMin', 'VARCHAR(50)'),
             ('budget', 'VARCHAR(50)'),
+            ('budgetMax', 'VARCHAR(50)'),
+            ('secteurGeographique', 'TEXT'),
+            ('delaiSouhaite', 'VARCHAR(50)'),
+            ('motivations', 'TEXT'),
             ('criteres', 'TEXT'),
             ('biensProposes', 'TEXT'),
-            ('statutDemande', 'VARCHAR(100)')
+            ('statutDemande', 'VARCHAR(100)'),
+            ('agentSuivi', 'VARCHAR(120)')
         ],
         'gestion_locative': [
+            ('referenceMandat', 'VARCHAR(50)'),
             ('adresse', 'TEXT'),
             ('proprietaire', 'VARCHAR(120)'),
+            ('proprietaireCoordonnees', 'TEXT'),
+            ('locataire', 'VARCHAR(120)'),
+            ('locataireCoordonnees', 'TEXT'),
             ('dateDebutBail', 'VARCHAR(50)'),
+            ('finBail', 'VARCHAR(50)'),
             ('loyer', 'VARCHAR(50)'),
+            ('montantCharges', 'VARCHAR(50)'),
+            ('depotGarantie', 'VARCHAR(50)'),
+            ('irl', 'VARCHAR(50)'),
+            ('dateProchaineIndexation', 'VARCHAR(50)'),
             ('statutLoyer', 'VARCHAR(100)'),
             ('datePaiement', 'VARCHAR(50)'),
             ('observations', 'TEXT')

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,21 +22,13 @@ const registerDefinitions = {
     icon: Briefcase,
     endpoint: 'mandats',
     fields: [
-      { name: 'numero', label: 'N° Mandat', required: true, placeholder: 'Ex. M-2024-001' },
-      { name: 'dateSignature', label: 'Date de signature', type: 'date' },
+      { name: 'referenceMandat', label: 'Référence mandat', required: true, placeholder: 'Ex. M-2024-001' },
       {
         name: 'typeMandat',
         label: 'Type de mandat',
         type: 'select',
         placeholder: 'Sélectionnez un type',
-        options: ['Simple', 'Exclusif', 'Semi-exclusif', 'Recherche', 'Autre']
-      },
-      {
-        name: 'statutMandat',
-        label: 'Statut du mandat',
-        type: 'select',
-        placeholder: 'Choisir un statut',
-        options: ['En préparation', 'En cours', 'Suspendu', 'Résilié', 'Finalisé']
+        options: ['Vente Simple', 'Vente Exclusif', 'Location Simple', 'Location Exclusif', 'Autre']
       },
       {
         name: 'typeTransaction',
@@ -45,36 +37,79 @@ const registerDefinitions = {
         placeholder: 'Sélectionnez une transaction',
         options: ['Vente', 'Achat', 'Location', 'Gestion', 'Autre']
       },
-      { name: 'proprietaire', label: 'Propriétaire', placeholder: 'Nom complet du propriétaire' },
       {
-        name: 'adresse',
-        label: 'Adresse',
-        type: 'textarea',
-        fullWidth: true,
-        placeholder: 'Adresse complète du bien'
+        name: 'typeBien',
+        label: 'Type de bien',
+        type: 'select',
+        placeholder: 'Sélectionnez un type de bien',
+        options: ['Maison', 'Appartement', 'Terrain', 'Bureau', 'Local commercial', 'Autre']
       },
       {
-        name: 'caracteristiques',
-        label: 'Caractéristiques',
+        name: 'adresseBien',
+        label: 'Adresse complète du bien',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Surface, pièces, prestations...'
+        placeholder: 'Adresse postale complète et précisions d’accès'
       },
-      { name: 'prixSouhaite', label: 'Prix souhaité', placeholder: 'Ex. 250 000 €' },
-      { name: 'commission', label: 'Commission', placeholder: 'Ex. 5 %' },
-      { name: 'validite', label: 'Validité', placeholder: 'Durée ou date de fin' },
-      { name: 'dateFinalisation', label: 'Date de finalisation', type: 'date' },
-      { name: 'acquereur', label: 'Acquéreur', placeholder: 'Nom de l’acquéreur' }
+      { name: 'surfaceM2', label: 'Surface (m²)', type: 'number', placeholder: 'Ex. 125' },
+      { name: 'nbPieces', label: 'Nombre de pièces', type: 'number', placeholder: 'Ex. 5' },
+      {
+        name: 'dpeClassement',
+        label: 'Classement DPE',
+        type: 'select',
+        options: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'Non renseigné']
+      },
+      { name: 'prixDemande', label: 'Prix demandé (FCFA)', type: 'number', placeholder: 'Ex. 150000000' },
+      { name: 'honorairePourcent', label: 'Honoraires agence (%)', type: 'number', placeholder: 'Ex. 5' },
+      { name: 'tvaApplicable', label: 'TVA applicable (%)', type: 'number', placeholder: 'Ex. 18' },
+      { name: 'proprietaireNom', label: 'Propriétaire / vendeur', required: true, placeholder: 'Nom et prénom du propriétaire' },
+      {
+        name: 'proprietaireCoordonnees',
+        label: 'Coordonnées propriétaire / vendeur',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Téléphone, email, adresse postale...'
+      },
+      {
+        name: 'clientVendeurInfos',
+        label: 'Contacts complémentaires vendeur',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Mandataire, co-indivisaire, représentant légal...'
+      },
+      {
+        name: 'clientAcheteurInfos',
+        label: 'Client acquéreur / locataire (coordonnées)',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Nom, téléphone, email des prospects intéressés'
+      },
+      { name: 'dateDebut', label: 'Date de début de mandat', type: 'date' },
+      { name: 'dateEcheance', label: "Date d'échéance", type: 'date' },
+      { name: 'agentResponsable', label: 'Agent responsable', placeholder: 'Nom de l’agent en charge' },
+      {
+        name: 'descriptionBien',
+        label: 'Description du bien',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Résumé des atouts du bien, environnement, travaux réalisés...'
+      },
+      {
+        name: 'notesMandat',
+        label: 'Notes internes / suivi mandat',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Clauses spécifiques, points de vigilance, instructions propriétaires...'
+      }
     ],
     columns: [
-      { name: 'numero', label: 'N° Mandat' },
-      { name: 'dateSignature', label: 'Date signature' },
+      { name: 'referenceMandat', label: 'Référence mandat' },
       { name: 'typeMandat', label: 'Type' },
-      { name: 'statutMandat', label: 'Statut' },
-      { name: 'typeTransaction', label: 'Transaction' },
-      { name: 'proprietaire', label: 'Propriétaire' },
-      { name: 'adresse', label: 'Adresse', wrap: true },
-      { name: 'prixSouhaite', label: 'Prix souhaité' }
+      { name: 'typeBien', label: 'Bien' },
+      { name: 'proprietaireNom', label: 'Propriétaire / vendeur', wrap: true },
+      { name: 'agentResponsable', label: 'Agent' },
+      { name: 'prixDemande', label: 'Prix demandé (FCFA)' },
+      { name: 'dateEcheance', label: 'Échéance' }
     ]
   },
   suivi: {
@@ -82,39 +117,46 @@ const registerDefinitions = {
     icon: TrendingUp,
     endpoint: 'suivi',
     fields: [
-      { name: 'numeroMandat', label: 'Réf. Mandat', required: true, placeholder: 'Mandat concerné' },
-      { name: 'dateSuivi', label: "Date de l'action", type: 'date' },
+      { name: 'referenceMandat', label: 'Référence mandat', required: true, placeholder: 'Mandat concerné' },
+      { name: 'dateAction', label: "Date de l'action", type: 'date' },
       {
-        name: 'action',
+        name: 'typeAction',
         label: 'Action réalisée',
         type: 'select',
         placeholder: 'Sélectionnez une action',
-        options: ['Appel téléphonique', 'Email', 'Visite', 'Relance', 'Autre']
+        options: ['Visite', 'Appel téléphonique', 'Email', 'Offre reçue', 'Relance propriétaire', 'Campagne marketing', 'Autre']
       },
-      { name: 'contact', label: 'Contact associé', placeholder: 'Nom du contact' },
       {
-        name: 'resultat',
-        label: 'Résultat',
+        name: 'intensiteAction',
+        label: "Intensité de l'action",
+        type: 'select',
+        options: ['Faible', 'Moyenne', 'Forte']
+      },
+      { name: 'contactClient', label: 'Contact client', placeholder: 'Nom du contact impliqué' },
+      {
+        name: 'details',
+        label: 'Détails / commentaires',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Compte-rendu de l’action'
+        placeholder: 'Résultat de la relance, feedback client, points à retenir...'
       },
+      { name: 'agent', label: 'Agent enregistreur', placeholder: 'Agent ayant réalisé l’action' },
       {
         name: 'prochaineEtape',
-        label: 'Prochaine étape',
+        label: 'Prochaine étape planifiée',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Actions à prévoir'
+        placeholder: 'Action à prévoir et objectifs associés'
       },
-      { name: 'datePrevue', label: 'Date prévue', type: 'date' }
+      { name: 'dateProchaineAction', label: 'Date prochaine action', type: 'date' }
     ],
     columns: [
-      { name: 'numeroMandat', label: 'Réf. Mandat' },
-      { name: 'dateSuivi', label: 'Date' },
-      { name: 'action', label: 'Action' },
-      { name: 'contact', label: 'Contact' },
-      { name: 'resultat', label: 'Résultat', wrap: true },
-      { name: 'prochaineEtape', label: 'Prochaine étape', wrap: true }
+      { name: 'referenceMandat', label: 'Référence mandat' },
+      { name: 'dateAction', label: 'Date' },
+      { name: 'typeAction', label: 'Action' },
+      { name: 'intensiteAction', label: 'Intensité' },
+      { name: 'contactClient', label: 'Contact client' },
+      { name: 'agent', label: 'Agent' }
     ]
   },
   transactions: {
@@ -123,35 +165,49 @@ const registerDefinitions = {
     endpoint: 'transactions',
     fields: [
       { name: 'numeroTransaction', label: 'N° Transaction', required: true, placeholder: 'Ex. T-2024-001' },
-      { name: 'dateTransaction', label: 'Date', type: 'date' },
-      { name: 'mandatRef', label: 'Réf. Mandat', placeholder: 'Mandat lié' },
+      { name: 'referenceMandat', label: 'Référence mandat', required: true, placeholder: 'Mandat lié' },
       {
         name: 'typeTransaction',
         label: 'Type de transaction',
         type: 'select',
         placeholder: 'Sélectionnez un type',
-        options: ['Vente', 'Achat', 'Location', 'Cession', 'Autre']
+        options: ['Vente définitive', 'Location signée', 'Compromis', 'Promesse', 'Autre']
       },
-      { name: 'bien', label: 'Bien concerné', placeholder: 'Appartement, maison...' },
-      { name: 'prix', label: 'Prix', placeholder: 'Montant total' },
-      { name: 'commissionTotale', label: 'Commission totale', placeholder: 'Montant de la commission' },
-      { name: 'client', label: 'Client', placeholder: 'Nom du client' },
+      { name: 'dateSignature', label: 'Date de signature / compromis', type: 'date' },
+      { name: 'clientVendeur', label: 'Client vendeur / bailleur', placeholder: 'Nom complet du vendeur' },
+      { name: 'acquereurLocataire', label: 'Acquéreur / locataire', required: true, placeholder: 'Nom complet de la contrepartie' },
+      { name: 'notaire', label: 'Notaire (si vente)', placeholder: 'Étude notariale en charge' },
+      { name: 'prixFinal', label: 'Prix final ou loyer (FCFA)', type: 'number', placeholder: 'Montant conclu' },
+      { name: 'commissionHT', label: 'Commission agence HT (FCFA)', type: 'number', placeholder: 'Montant HT' },
+      { name: 'montantTVA', label: 'Montant TVA (FCFA)', type: 'number', placeholder: 'Montant de TVA' },
       {
-        name: 'observations',
-        label: 'Observations',
+        name: 'conditionsSusp',
+        label: 'Conditions suspensives',
+        type: 'select',
+        options: ['Oui', 'Non']
+      },
+      {
+        name: 'statutReglement',
+        label: 'Statut règlement commission',
+        type: 'select',
+        options: ['En attente', 'Partiellement réglée', 'Réglée']
+      },
+      {
+        name: 'notesTransaction',
+        label: 'Notes sur la transaction',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Informations complémentaires'
+        placeholder: 'Conditions particulières, échéancier de paiement, observations diverses'
       }
     ],
     columns: [
       { name: 'numeroTransaction', label: 'N° Transaction' },
-      { name: 'dateTransaction', label: 'Date' },
-      { name: 'mandatRef', label: 'Réf. Mandat' },
+      { name: 'referenceMandat', label: 'Référence mandat' },
       { name: 'typeTransaction', label: 'Type' },
-      { name: 'bien', label: 'Bien', wrap: true },
-      { name: 'prix', label: 'Prix' },
-      { name: 'commissionTotale', label: 'Commission' }
+      { name: 'clientVendeur', label: 'Vendeur / bailleur', wrap: true },
+      { name: 'acquereurLocataire', label: 'Acquéreur / locataire', wrap: true },
+      { name: 'prixFinal', label: 'Prix final (FCFA)' },
+      { name: 'statutReglement', label: 'Règlement commission' }
     ]
   },
   gestion_locative: {
@@ -159,41 +215,60 @@ const registerDefinitions = {
     icon: Home,
     endpoint: 'gestion',
     fields: [
-      { name: 'numeroBien', label: 'Réf. Bien', required: true, placeholder: 'Ex. B-2024-001' },
+      { name: 'referenceMandat', label: 'Référence mandat', placeholder: 'Mandat de gestion lié' },
+      { name: 'numeroBien', label: 'Référence bien', required: true, placeholder: 'Ex. B-2024-001' },
       {
-        name: 'adresse',
-        label: 'Adresse',
+        name: 'adresseBien',
+        label: 'Adresse complète du bien',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Adresse complète du bien'
+        placeholder: 'Adresse, étage, accès, particularités...'
       },
-      { name: 'proprietaire', label: 'Propriétaire', placeholder: 'Nom du bailleur' },
-      { name: 'locataire', label: 'Locataire', placeholder: 'Nom du locataire' },
-      { name: 'dateDebutBail', label: 'Début du bail', type: 'date' },
-      { name: 'loyer', label: 'Loyer', placeholder: 'Montant mensuel' },
+      { name: 'proprietaireNom', label: 'Propriétaire / bailleur', required: true },
       {
-        name: 'statutLoyer',
-        label: 'Statut du loyer',
+        name: 'proprietaireCoordonnees',
+        label: 'Coordonnées propriétaire',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Téléphone, email, adresse de correspondance'
+      },
+      { name: 'locataireNom', label: 'Locataire', required: true },
+      {
+        name: 'locataireCoordonnees',
+        label: 'Coordonnées locataire',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Téléphone, email, adresse de facturation'
+      },
+      { name: 'debutBail', label: 'Début du bail', type: 'date' },
+      { name: 'finBail', label: 'Fin du bail', type: 'date' },
+      { name: 'montantLoyerBase', label: 'Loyer hors charges (FCFA)', type: 'number' },
+      { name: 'montantCharges', label: 'Charges mensuelles (FCFA)', type: 'number' },
+      { name: 'depotGarantie', label: 'Dépôt de garantie (FCFA)', type: 'number' },
+      { name: 'irl', label: 'Indice IRL appliqué', placeholder: 'Indice de référence des loyers' },
+      { name: 'dateProchaineIndexation', label: 'Prochaine indexation', type: 'date' },
+      {
+        name: 'etatPaiement',
+        label: 'Statut paiement',
         type: 'select',
-        placeholder: 'Sélectionnez un statut',
-        options: ['Payé', 'Partiellement payé', 'En retard', 'Impayé']
+        options: ['À jour', 'En retard', 'Impayé']
       },
-      { name: 'datePaiement', label: 'Date de paiement', type: 'date' },
+      { name: 'datePaiement', label: 'Date dernier paiement', type: 'date' },
       {
-        name: 'observations',
-        label: 'Observations',
+        name: 'notesIncident',
+        label: 'Incidents / travaux',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Notes sur le bail ou le locataire'
+        placeholder: 'Retards, réparations, communications avec le locataire...'
       }
     ],
     columns: [
-      { name: 'numeroBien', label: 'Réf. Bien' },
-      { name: 'locataire', label: 'Locataire' },
-      { name: 'proprietaire', label: 'Propriétaire' },
-      { name: 'dateDebutBail', label: 'Début bail' },
-      { name: 'loyer', label: 'Loyer' },
-      { name: 'statutLoyer', label: 'Statut du loyer' }
+      { name: 'numeroBien', label: 'Référence bien' },
+      { name: 'referenceMandat', label: 'Mandat lié' },
+      { name: 'locataireNom', label: 'Locataire' },
+      { name: 'proprietaireNom', label: 'Propriétaire', wrap: true },
+      { name: 'montantLoyerBase', label: 'Loyer HC (FCFA)' },
+      { name: 'etatPaiement', label: 'Statut paiement' }
     ]
   },
   recherche: {
@@ -202,45 +277,67 @@ const registerDefinitions = {
     endpoint: 'recherche',
     fields: [
       { name: 'numeroDemande', label: 'N° Demande', required: true, placeholder: 'Ex. D-2024-001' },
-      { name: 'dateDemande', label: 'Date', type: 'date' },
-      { name: 'client', label: 'Client', placeholder: 'Nom du client' },
+      { name: 'dateDemande', label: 'Date de la demande', type: 'date' },
+      { name: 'clientNom', label: 'Nom complet du client', required: true },
+      { name: 'telephone', label: 'Téléphone', required: true, placeholder: 'Ex. +225 00 00 00 00' },
       {
-        name: 'typeBien',
-        label: 'Type de bien',
+        name: 'typeRecherche',
+        label: 'Type de recherche',
         type: 'select',
-        placeholder: 'Sélectionnez un type de bien',
-        options: ['Appartement', 'Maison', 'Terrain', 'Local commercial', 'Bureau', 'Autre']
+        placeholder: 'Sélectionnez un type',
+        options: ['Achat résidence principale', 'Achat investissement', 'Location']
       },
-      { name: 'budget', label: 'Budget', placeholder: 'Montant estimé' },
+      { name: 'budgetMin', label: 'Budget minimum (FCFA)', type: 'number' },
+      { name: 'budgetMax', label: 'Budget maximum (FCFA)', type: 'number' },
       {
-        name: 'criteres',
-        label: 'Critères',
+        name: 'secteurGeographique',
+        label: 'Secteurs géographiques recherchés',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Surface, localisation, prestations...'
+        placeholder: 'Quartiers, villes, zones prioritaires'
+      },
+      {
+        name: 'delaiSouhaite',
+        label: 'Délai souhaité',
+        type: 'select',
+        options: ['Immédiat (< 3 mois)', 'Moyen terme (3-6 mois)', 'Long terme (> 6 mois)']
+      },
+      {
+        name: 'motivations',
+        label: 'Motivations / urgence',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Projet de vie, investissement, mobilité professionnelle...'
+      },
+      {
+        name: 'criteresSpecifiques',
+        label: 'Critères spécifiques',
+        type: 'textarea',
+        fullWidth: true,
+        placeholder: 'Surface minimale, nombre de pièces, prestations attendues...'
       },
       {
         name: 'biensProposes',
-        label: 'Biens proposés',
+        label: 'Biens déjà proposés',
         type: 'textarea',
         fullWidth: true,
-        placeholder: 'Biens envoyés au client'
+        placeholder: 'Historique des propositions envoyées au client'
       },
       {
         name: 'statutDemande',
-        label: 'Statut',
+        label: 'Statut de la demande',
         type: 'select',
-        placeholder: 'Sélectionnez un statut',
-        options: ['En attente', 'En recherche', 'Proposition envoyée', 'Clôturée', 'Annulée']
-      }
+        options: ['En attente', 'En recherche active', 'Proposition envoyée', 'Clôturée', 'Annulée']
+      },
+      { name: 'agentSuivi', label: 'Agent en charge', placeholder: 'Conseiller responsable du dossier' }
     ],
     columns: [
       { name: 'numeroDemande', label: 'N° Demande' },
-      { name: 'dateDemande', label: 'Date' },
-      { name: 'client', label: 'Client' },
-      { name: 'typeBien', label: 'Type de bien' },
-      { name: 'budget', label: 'Budget' },
-      { name: 'statutDemande', label: 'Statut' }
+      { name: 'clientNom', label: 'Client' },
+      { name: 'telephone', label: 'Téléphone' },
+      { name: 'typeRecherche', label: 'Type de recherche' },
+      { name: 'budgetMax', label: 'Budget max (FCFA)' },
+      { name: 'agentSuivi', label: 'Agent' }
     ]
   }
 };


### PR DESCRIPTION
## Summary
- align backend register models around a shared mandate reference and extend them with detailed client contact fields
- update schema migration helper to backfill the new columns on existing SQLite tables
- refresh frontend register definitions so every form captures vendor, buyer and tenant details and surfaces them in table views

## Testing
- npm run build
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68df97aeccac832cb572ddfa4e96a27a