### PR TITLE
Fix API serialization for models with column aliases

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -318,7 +318,8 @@ def ensure_schema():
 
 
 def to_dict(obj):
-    return {c.key: getattr(obj, c.key) for c in obj.__table__.columns}
+    mapper = inspect(obj.__class__)
+    return {attr.key: getattr(obj, attr.key) for attr in mapper.column_attrs}
 
 
 def error_response(message, status):


### PR DESCRIPTION
## Summary
- update the generic serializer to rely on SQLAlchemy's mapped attribute metadata
- ensure models using database column aliases (e.g., Mandat.numero) serialize without raising errors

## Testing
- python - <<'PY'
from backend.app import Mandat, to_dict
m = Mandat(referenceMandat='ref1')
print(to_dict(m))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dfa8210c8c832ca3ba43666228c9f5